### PR TITLE
chore(*): Fix root dir for typedoc plugin since it's now under src.

### DIFF
--- a/plugins/typedoc-plugin-react-components/tsconfig.json
+++ b/plugins/typedoc-plugin-react-components/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./",
+    "rootDir": "./src",
     "outDir": "./dist",
     "target": "ESNext",
     "module": "ESNext",


### PR DESCRIPTION
In master building the plugin: 

```
npm run build:plugin   
```
and then building typedoc:

```
npm run build:typedoc:exports
```

Throws error: Cannot find module 'C:\Github\Repos\api-docs\temp\igniteui-react\plugins\typedoc-plugin-react-components\dist\main.js'

Because it's now under an additional src folder.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 