### PR TITLE
fix(skills): css name of the navdrawer property

### DIFF
--- a/skills/igniteui-react-generate-from-image-design/reference/gotchas.md
+++ b/skills/igniteui-react-generate-from-image-design/reference/gotchas.md
@@ -139,8 +139,8 @@ For core UI component theming, prefer `create_component_theme` and apply the ret
 Override the drawer width using the nav drawer CSS custom properties measured from the design image:
 ```css
 igc-nav-drawer {
-  --ig-nav-drawer-size: <extracted-sidebar-width>;
-  --ig-nav-drawer-size--mini: <extracted-mini-drawer-width>;
+  --menu-full-width: <extracted-sidebar-width>;
+  --menu-mini-width: <extracted-mini-drawer-width>;
 }
 ```
 


### PR DESCRIPTION
## Description
There is an inconsistency in Nav Drawer CSS custom property naming across Ignite UI platforms

- **igniteui-angular** uses:
  - `--ig-nav-drawer-size`
  - `--ig-nav-drawer-size--mini`
- **igniteui-webcomponents** (and therefore **igniteui-react**, which wraps WC) uses:
  - `--menu-full-width`
  - `--menu-mini-width`
  
  But in React skills there is a reference like this:
<img width="778" height="145" alt="image" src="https://github.com/user-attachments/assets/174e7f2b-efee-4de9-8ef4-89ae4e76d16e" />



  This will be fixed with https://github.com/IgniteUI/igniteui-webcomponents/issues/2240 but in the mean time we have to adjust the react skills according to the current css prop name `--menu-full-width `