### PR TITLE
fix(npm): restore packages dist structure

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./",
+    "rootDir": "./src",
     "outDir": "./dist",
     "target": "ESNext",
     "module": "ESNext",


### PR DESCRIPTION
[A seemingly benign `"rootDir": "./",` snuck in `19.6.2` with some deps updates](https://github.com/IgniteUI/igniteui-react/pull/152/changes#diff-b55cdbef4907b7045f32cc5360d48d262cca5f94062e353089f189f4460039e0R3), but because all included files were in `src/` that was also the previous _implicit_ root, so the change moved all declarations to /src instead:

<img width="779" height="460" alt="image" src="https://github.com/user-attachments/assets/2079b285-9b49-43b6-9d39-ea13f980959a" />

 https://www.npmjs.com/package/igniteui-react/v/19.6.2?activeTab=code

<img width="770" height="635" alt="image" src="https://github.com/user-attachments/assets/924f7523-8399-4992-8906-ae16c60a9c25" />

 https://www.npmjs.com/package/igniteui-react/v/19.6.1?activeTab=code
 
Causing all packages to loose their typings:
<img width="936" height="183" alt="image" src="https://github.com/user-attachments/assets/0469d94b-1c98-44d4-a3d7-fa92b483c402" />
