### PR TITLE
ci: migrate ci workflow to github action

### DIFF
--- a/.github/actions/setup-build-test/action.yml
+++ b/.github/actions/setup-build-test/action.yml
@@ -1,0 +1,50 @@
+name: 'Setup, build & test'
+description: 'Install Node.js and dependencies, build, validate dist packages, lint and test. Shared by CI and release workflows.'
+
+inputs:
+  licensed:
+    description: 'Produce a licensed (@infragistics scoped) build'
+    required: false
+    default: 'false'
+  verbose:
+    description: 'Get verbose npm output where configurable'
+    required: false
+    default: 'false'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '24.x'
+        cache: 'npm'
+
+    - name: npm ci
+      shell: bash
+      run: npm ci ${{ inputs.verbose == 'true' && '--loglevel verbose' || '' }}
+
+    - name: Build
+      shell: bash
+      run: npm run build ${{ inputs.verbose == 'true' && '--loglevel verbose' || '' }}
+      env:
+        # Only truthy when licensed; empty string keeps unlicensed builds unscoped.
+        IG_LICENSED_BUILD: ${{ inputs.licensed == 'true' && 'true' || '' }}
+
+    - name: Validate dist packages
+      shell: bash
+      run: npm run validate:dist ${{ inputs.verbose == 'true' && '--loglevel verbose' || '' }}
+
+    - name: Lint
+      shell: bash
+      run: npm run lint ${{ inputs.verbose == 'true' && '--loglevel verbose' || '' }}
+
+    - name: Install Playwright browsers
+      shell: bash
+      run: npx playwright install chromium-headless-shell
+
+    - name: Test
+      shell: bash
+      run: npm run test:ci ${{ inputs.verbose == 'true' && '--loglevel verbose' || '' }}
+      env:
+        CI: 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+  workflow_dispatch:
+    inputs:
+      verbose:
+        description: 'Get verbose output from steps - where configurable'
+        type: boolean
+        default: false
+
+# Cancel superseded PR runs; let master pushes each run to completion for history.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+  # Required by actions/upload-code-coverage to post coverage on the PR.
+  code-quality: write
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup, build & test
+        uses: ./.github/actions/setup-build-test
+        with:
+          verbose: ${{ inputs.verbose || 'false' }}
+
+      - name: Upload code coverage
+        # Skip on PRs from forks, where the token can't post coverage.
+        if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        uses: actions/upload-code-coverage@v1
+        with:
+          file: coverage/cobertura-coverage.xml
+          language: typescript
+          label: React Wrappers
+
+      - name: Upload test results artifact
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: test-report
+          path: test-report/junit-report.xml
+          if-no-files-found: warn
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: coverage
+          path: coverage/
+          if-no-files-found: warn


### PR DESCRIPTION
# Migrate CI from Azure Pipelines to GitHub Actions

Ports the CI pipeline from Azure Pipelines to GitHub Actions, keeping the build/test steps in a shared, reusable unit so the release pipeline can be migrated the same way later.

## What changed

- **New composite action** `.github/actions/setup-build-test` — the shared equivalent of `setup-build-test-steps.yml`. Installs Node, runs `npm ci`, build, `validate:dist`, lint, installs Playwright, and runs `test:ci`. Exposes `licensed` and `verbose` inputs. Both CI and the future release workflow can consume it via `uses: ./.github/actions/setup-build-test`.
- **New workflow** `.github/workflows/ci.yml` — replaces `.azure-pipelines/ci.yml`. Runs the composite action, then publishes coverage and uploads reports.

## Notable translation decisions

- **Checkout lives in the workflow, not the composite action.** A local composite action can't check out the repo itself — the code must already be present for GitHub to load `action.yml` — so checkout stays in each caller and the reusable core is everything after it.
- **`IG_LICENSED_BUILD` truthiness preserved.** The build scripts treat any non-empty value (including `"false"`) as licensed, so the env var is set to `'true'` only when `licensed` is true and to an empty string otherwise, matching Azure's `if eq(parameters.licensed, true)` guard.
- **`verbose`** maps to `--loglevel verbose` appended to the npm scripts, mirroring the Azure `Npm@1` verbose option.
- **Triggers:** `pull_request` → `master` and `push` → `master`, plus `workflow_dispatch` (exposing the `verbose` toggle). A `concurrency` group cancels superseded PR runs while letting master-push runs complete for history.
- **Coverage/test reporting:** uses the first-party (public preview) `actions/upload-code-coverage@v1` to surface coverage on the PR from the existing Cobertura report (`coverage/cobertura-coverage.xml`), and uploads the JUnit report and full coverage directory as artifacts. No third-party actions introduced.

## Notes / follow-ups

- `actions/upload-code-coverage@v1` is in public preview and requires the `code-quality: write` permission (set in the workflow); the Code Coverage preview may need to be enabled for the repo/org.
- The built-in action posts coverage on the PR rather than as an expandable run-Summary block. The blazor-style run-Summary list would require the third-party ReportGenerator action; not included here to stay first-party.
- The old `.azure-pipelines/` CI files are left in place for now and can be retired once the release pipeline is migrated too.
